### PR TITLE
adds custom amount param when requesting tokens from faucet

### DIFF
--- a/frontend/faucet/api.go
+++ b/frontend/faucet/api.go
@@ -40,7 +40,6 @@ func (f *faucet) requestCoins(w http.ResponseWriter, r *http.Request) {
 
 	var txID types.TransactionID
 	if body.Amount.IsZero() {
-		log.Printf("no amount is provided so im using default amount")
 		txID, err = dripCoins(body.Address, f.coinsToGive)
 	} else {
 		// If there is an amount requested, use the provided amount

--- a/frontend/faucet/api.go
+++ b/frontend/faucet/api.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/nbh-digital/goldchain/pkg/config"
 	"github.com/threefoldtech/rivine/types"
 )
 
@@ -23,6 +24,7 @@ func (f *faucet) requestCoins(w http.ResponseWriter, r *http.Request) {
 
 	body := struct {
 		Address types.UnlockHash `json:"address"`
+		Amount  types.Currency   `json:"amount"`
 	}{}
 
 	err := json.NewDecoder(r.Body).Decode(&body)
@@ -35,7 +37,16 @@ func (f *faucet) requestCoins(w http.ResponseWriter, r *http.Request) {
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	txID, err := dripCoins(body.Address, f.coinsToGive)
+
+	var txID types.TransactionID
+	if body.Amount.IsZero() {
+		log.Printf("no amount is provided so im using default amount")
+		txID, err = dripCoins(body.Address, f.coinsToGive)
+	} else {
+		// If there is an amount requested, use the provided amount
+		amount, _ := body.Amount.Uint64()
+		txID, err = dripCoins(body.Address, config.GetTestnetGenesis().CurrencyUnits.OneCoin.Mul64(amount))
+	}
 
 	if err != nil {
 		log.Println("[ERROR] Failed to drip coins:", err)

--- a/frontend/faucet/api.go
+++ b/frontend/faucet/api.go
@@ -24,7 +24,7 @@ func (f *faucet) requestCoins(w http.ResponseWriter, r *http.Request) {
 
 	body := struct {
 		Address types.UnlockHash `json:"address"`
-		Amount  types.Currency   `json:"amount"`
+		Amount  uint64           `json:"amount"`
 	}{}
 
 	err := json.NewDecoder(r.Body).Decode(&body)
@@ -39,12 +39,11 @@ func (f *faucet) requestCoins(w http.ResponseWriter, r *http.Request) {
 	defer f.mu.Unlock()
 
 	var txID types.TransactionID
-	if body.Amount.IsZero() {
+	if body.Amount == 0 {
 		txID, err = dripCoins(body.Address, f.coinsToGive)
 	} else {
 		// If there is an amount requested, use the provided amount
-		amount, _ := body.Amount.Uint64()
-		txID, err = dripCoins(body.Address, config.GetTestnetGenesis().CurrencyUnits.OneCoin.Mul64(amount))
+		txID, err = dripCoins(body.Address, config.GetTestnetGenesis().CurrencyUnits.OneCoin.Mul64(body.Amount))
 	}
 
 	if err != nil {

--- a/frontend/faucet/doc/api.md
+++ b/frontend/faucet/doc/api.md
@@ -16,7 +16,7 @@ data:
 ```json
 {
 	"address": "UnlockHash string",
-	"amount": "Amount of tokens | optional (default 300)"
+	"amount": "Amount of tokens unint64 | optional (default 300)"
 }
 ```
 

--- a/frontend/faucet/doc/api.md
+++ b/frontend/faucet/doc/api.md
@@ -15,7 +15,8 @@ data:
 
 ```json
 {
-	"address": "UnlockHash string"
+	"address": "UnlockHash string",
+	"amount": "Amount of tokens | optional (default 300)"
 }
 ```
 


### PR DESCRIPTION
A custom amount parameter can now be passed through the API when requesting tokens from the faucet.

closes #39 